### PR TITLE
removed dependency on deprecated template module

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -1,19 +1,12 @@
-data "template_file" "basicauth" {
-  count    = length(var.authentication) > 0 ? var.enabled ? 1 : 0 : 0
-  template = "${file("${path.module}/templates/basicauth.js")}"
-
-  vars = {
-    authentication = "${jsonencode(var.authentication)}"
-  }
-}
-
 data "archive_file" "basicauth" {
   count       = length(var.authentication) > 0 ? var.enabled ? 1 : 0 : 0
   type        = "zip"
   output_path = "./files/lambda/${var.name}-basicauth.zip"
 
   source {
-    content  = "${data.template_file.basicauth.0.rendered}"
+    content = templatefile("${path.module}/templates/basicauth.js", {
+      authentication = "${jsonencode(var.authentication)}"
+    })
     filename = "index.js"
   }
 }
@@ -26,6 +19,6 @@ resource "aws_lambda_function" "basicauth" {
   role             = aws_iam_role.lambda.0.arn
   handler          = "index.handler"
   source_code_hash = data.archive_file.basicauth.0.output_base64sha256
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs16.x"
   publish          = true
 }

--- a/s3buckets.tf
+++ b/s3buckets.tf
@@ -50,14 +50,20 @@ resource "aws_s3_bucket" "website" {
     index_document = var.index_document
   }
 
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+
+resource "aws_s3_bucket_cors_configuration" "website" {
+  count  = var.enabled ? 1 : 0
+  bucket = aws_s3_bucket.website.0.bucket
+
   cors_rule {
     allowed_origins = ["*"]
     allowed_methods = ["HEAD", "GET", "PUT", "POST", "DELETE"]
     max_age_seconds = 3000
     allowed_headers = ["*"]
-  }
-
-  lifecycle {
-    prevent_destroy = true
   }
 }


### PR DESCRIPTION
* replaced `template_file` that requires the deprecated `template` module with the modern `templatefile` function
* refactored the s3 bucket code to use the aws v4 provider standards (`aws_s3_bucket_cors_configuration` is a resource now)
* updated the nodejs version to the latest LTS (16.x)

I've ran a quick test against a "rendered" js template to make sure it doesn't throw any errors in Node16: 
`docker run -it --rm --name node-test -v "$PWD":/usr/src/app -w /usr/src/app node:latest node basicauth_test.js`

I'll include some people who are more experienced with Node as reviewers to make sure my version upgrade didn't break anything.