### PR TITLE
Fix: deprecated warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ module "static_site" {
   ]
 
   providers = {
-    aws        = "aws"
-    aws.useast = "aws.useast"  # Required for Lambda@Edge
+    aws        = aws
+    aws.useast = aws.useast  # Required for Lambda@Edge
   }
 }
 ```

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,11 @@
-provider "aws" {}
-
-provider "aws" {
-  alias = "useast"
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      configuration_aliases = [
+        aws,
+        aws.useast
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Fixed `Warning: Redundant empty provider block` and `Warning: Quoted references are deprecated`.
Updated readme for usage without deprecated references. 